### PR TITLE
Release v2021.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,9 @@ package:
 source:
   url: https://github.com/intel/scikit-learn-intelex/archive/{{ version }}.tar.gz
   sha256: bbe3d889f722c154e22d141f3b194d7ceaefdddc710f8139cf0cbb9f0476bf18
+  patches:
+    - patches/0001-replace-check_estimator_sparse_data-in-tests.patch
+
 build:
   number: {{ buildnumber }}
   skip: True                  # [not ((win or linux or osx) and x86_64)]
@@ -23,6 +26,8 @@ requirements:
     - cmake
     - make   # [unix]
     - ninja  # [win]
+    - patch     # [unix]
+    - m2-patch  # [win]
   host:
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
-{% set version = "2021.4.0" %}
+{% set version = "2021.5.0" %}
 {% set buildnumber = 0 %}
+{% set dal_version = "2021.5.1" %}    # [linux]
+{% set dal_version = "2021.5.0" %}    # [osx or win]
 
 package:
   name: daal4py
@@ -7,7 +9,7 @@ package:
 
 source:
   url: https://github.com/intel/scikit-learn-intelex/archive/{{ version }}.tar.gz
-  sha256: 312fe4db3c03e8c17cd159d18afbdce8abf71c51247fc1cef756ac994b8b24e7
+  sha256: bbe3d889f722c154e22d141f3b194d7ceaefdddc710f8139cf0cbb9f0476bf18
 build:
   number: {{ buildnumber }}
   skip: True                  # [not ((win or linux or osx) and x86_64)]
@@ -27,7 +29,7 @@ requirements:
     - wheel
     - pip
     - numpy
-    - dal-devel {{ version }}
+    - dal-devel {{ dal_version }}
     - cython
     - jinja2
     - mpich                   # [not win]
@@ -35,7 +37,7 @@ requirements:
     - pybind11
   run:
     - python
-    - dal {{ version }}
+    - dal {{ dal_version }}
     - {{ pin_compatible('numpy') }}
   run_constrained:                                             # [osx]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.12") }}  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/intel/scikit-learn-intelex/archive/{{ version }}.tar.gz
-  sha256: bbe3d889f722c154e22d141f3b194d7ceaefdddc710f8139cf0cbb9f0476bf18
+  sha256: b0298ed384554077e8c49feb8092e895eb0f93dc98bc059cab8aede8a259acd8
   patches:
     - patches/0001-replace-check_estimator_sparse_data-in-tests.patch
     - winfix_ssize_t.patch  # [win]
@@ -17,6 +17,7 @@ source:
 build:
   number: {{ buildnumber }}
   skip: True                  # [not ((win or linux or osx) and x86_64)]
+  skip: True                  # [py==310]
   missing_dso_whitelist:      # [osx]
     - lib/libc++.1.dylib      # [osx]
 
@@ -50,7 +51,7 @@ requirements:
 
 test:
   requires:
-    - pandas ==1.2.5
+    - pandas
     - scipy
     - scikit-learn
     - xgboost

--- a/recipe/patches/0001-replace-check_estimator_sparse_data-in-tests.patch
+++ b/recipe/patches/0001-replace-check_estimator_sparse_data-in-tests.patch
@@ -1,0 +1,12 @@
+diff --git a/onedal/svm/tests/test_svc.py b/onedal/svm/tests/test_svc.py
+index b69965b..9697254 100644
+--- a/onedal/svm/tests/test_svc.py
++++ b/onedal/svm/tests/test_svc.py
+@@ -58,6 +58,7 @@ def test_estimator():
+         'check_estimators_fit_returns_self',  # ValueError: empty metadata
+         'check_classifiers_train',  # assert y_pred.shape == (n_samples,)
+         'check_estimators_unfitted',  # Call 'fit' with appropriate arguments
++        'check_estimator_sparse_data',  # This fails with scikit-learn v1.0.2
+     ], dummy)
+     check_estimator(SVC())
+     _restore_from_saved(md, saved)


### PR DESCRIPTION
Between `scikit-learn` v1.0.1 & v1.0.2, something within the [check_estimator_sparse_data](https://github.com/scikit-learn/scikit-learn/blob/1.0.2/sklearn/utils/estimator_checks.py#L783) method is causing segfaults / access violations during the `pytest --pyargs ../onedal/` call.

To get the tests passing, I added that method to a what looks like a list of items that monkey patched. 